### PR TITLE
Update deck workflow instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ These commands ensure dependencies are installed and the TypeScript code compile
 - Convert each metadata file there into a deck YAML under `decks/` using the same base name.
 - Keep deck names hierarchical with `::` separators to match Anki sub-decks.
 - When creating a deck from a metadata variant, also generate a `processed.txt` file
-  in the same folder containing the date of processing.
+  in the deck folder containing the date of processing.
 
 ## Pull Request Notes
 - Summaries must mention the purpose of the change and reference relevant files with line numbers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,17 @@ yarn build
 
 These commands ensure dependencies are installed and the TypeScript code compiles.
 
+## Deck Structure
+- Deck YAML files live in `decks/`. Each file must include `deck_name`, `model_name`, `primary_field`, and a `notes` array.
+- Each note entry should provide a `fields` mapping for card data and an optional `tags` list.
+
+## Adding New Decks
+- Source metadata lives under `processing/`.
+- Convert each metadata file there into a deck YAML under `decks/` using the same base name.
+- Keep deck names hierarchical with `::` separators to match Anki sub-decks.
+- When creating a deck from a metadata variant, also generate a `processed.txt` file
+  in the same folder containing the date of processing.
+
 ## Pull Request Notes
 - Summaries must mention the purpose of the change and reference relevant files with line numbers.
 - Include a testing section describing command results. If commands cannot run due to environment restrictions, state so explicitly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,10 @@ These commands ensure dependencies are installed and the TypeScript code compile
 - Each note entry should provide a `fields` mapping for card data and an optional `tags` list.
 
 ## Adding New Decks
-- Source metadata lives under `processing/`.
+- Source unproccessed metadata lives under `decks/processing/`.
 - Convert each metadata file there into a deck YAML under `decks/` using the same base name.
-- Keep deck names hierarchical with `::` separators to match Anki sub-decks.
-- When creating a deck from a metadata variant, also generate a `processed.txt` file
+- Keep deck names hierarchical with `::` separators to match Anki sub-decks (you can create a new directories).
+- When creating a deck from a metadata variant, also generate a `.metadata.json` file
   in the deck folder containing the date of processing.
 
 ## Pull Request Notes


### PR DESCRIPTION
## Summary
- clarify deck YAML layout
- document how to build decks from metadata in `processing/`
- note that generating a deck variant should also write a `processed.txt` file with the date

## Testing
- `yarn install && yarn build` *(ran earlier to satisfy programmatic checks)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685280d4bdf4832fbcfa2d60939d8b33